### PR TITLE
Reorganize key names

### DIFF
--- a/js/admin/src/components/PusherSettingsModal.js
+++ b/js/admin/src/components/PusherSettingsModal.js
@@ -6,23 +6,23 @@ export default class PusherSettingsModal extends SettingsModal {
   }
 
   title() {
-    return 'Pusher Settings';
+    return app.translator.trans('flarum-pusher.admin.pusher_settings.title');
   }
 
   form() {
     return [
       <div className="Form-group">
-        <label>App ID</label>
+        <label>{app.translator.trans('flarum-pusher.admin.pusher_settings.app_id_label')}</label>
         <input className="FormControl" bidi={this.setting('flarum-pusher.app_id')}/>
       </div>,
 
       <div className="Form-group">
-        <label>App Key</label>
+        <label>{app.translator.trans('flarum-pusher.admin.pusher_settings.app_key_label')}</label>
         <input className="FormControl" bidi={this.setting('flarum-pusher.app_key')}/>
       </div>,
 
       <div className="Form-group">
-        <label>App Secret</label>
+        <label>{app.translator.trans('flarum-pusher.admin.pusher_settings.app_secret_label')}</label>
         <input className="FormControl" bidi={this.setting('flarum-pusher.app_secret')}/>
       </div>
     ];

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -79,7 +79,7 @@ app.initializers.add('flarum-pusher', () => {
               this.loadingUpdated = true;
             },
             loading: this.loadingUpdated,
-            children: app.translator.transChoice('flarum-pusher.forum.show_updated_discussions', count, {count})
+            children: app.translator.transChoice('flarum-pusher.forum.discussion_list.show_updates_text', count, {count})
           })
         );
       }


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).
- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.
