### PR TITLE
added cluster option, couldnt generate forum js

### DIFF
--- a/js/admin/dist/extension.js
+++ b/js/admin/dist/extension.js
@@ -55,6 +55,15 @@ System.register('flarum/pusher/components/PusherSettingsModal', ['flarum/compone
                 app.translator.trans('flarum-pusher.admin.pusher_settings.app_secret_label')
               ),
               m('input', { className: 'FormControl', bidi: this.setting('flarum-pusher.app_secret') })
+            ), m(
+              'div',
+              { className: 'Form-group' },
+              m(
+                'label',
+                null,
+                app.translator.trans('flarum-pusher.admin.pusher_settings.app_cluster_label')
+              ),
+              m('input', { className: 'FormControl', bidi: this.setting('flarum-pusher.app_cluster') })
             )];
           }
         }]);

--- a/js/admin/src/components/PusherSettingsModal.js
+++ b/js/admin/src/components/PusherSettingsModal.js
@@ -24,6 +24,11 @@ export default class PusherSettingsModal extends SettingsModal {
       <div className="Form-group">
         <label>{app.translator.trans('flarum-pusher.admin.pusher_settings.app_secret_label')}</label>
         <input className="FormControl" bidi={this.setting('flarum-pusher.app_secret')}/>
+      </div>,
+
+      <div className="Form-group">
+        <label>{app.translator.trans('flarum-pusher.admin.pusher_settings.app_cluster_label')}</label>
+        <input className="FormControl" bidi={this.setting('flarum-pusher.app_cluster')}/>
       </div>
     ];
   }

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -13,6 +13,7 @@ app.initializers.add('flarum-pusher', () => {
   $.getScript('//js.pusher.com/3.0/pusher.min.js', () => {
     const socket = new Pusher(app.forum.attribute('pusherKey'), {
       authEndpoint: app.forum.attribute('apiUrl') + '/pusher/auth',
+      cluster: app.forum.attribute('pusherCluster'),
       auth: {
         headers: {
           'X-CSRF-Token': app.session.csrfToken

--- a/src/Listener/AddPusherApi.php
+++ b/src/Listener/AddPusherApi.php
@@ -49,6 +49,7 @@ class AddPusherApi
     {
         if ($event->isSerializer(ForumSerializer::class)) {
             $event->attributes['pusherKey'] = $this->settings->get('flarum-pusher.app_key');
+            $event->attributes['pusherCluster'] = $this->settings->get('flarum-pusher.app_cluster', 'us');
         }
     }
 


### PR DESCRIPTION
Pusher now allows for setting a cluster in the dashboard. If you don't configure that in your pusher settings you won't be able to connect if using any other cluster than US.

Sorry couldn't generate the forum dist extension.js for some reason. Admin side works though.
