### PR TITLE
Unbind only from newPost

### DIFF
--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -74,7 +74,7 @@ System.register('flarum/pusher/main', ['flarum/extend', 'flarum/app', 'flarum/co
             });
 
             extend(context, 'onunload', function () {
-              return channels.main.unbind();
+              return channels.main.unbind('newPost');
             });
           });
         });
@@ -151,7 +151,7 @@ System.register('flarum/pusher/main', ['flarum/extend', 'flarum/app', 'flarum/co
             });
 
             extend(context, 'onunload', function () {
-              return channels.main.unbind();
+              return channels.main.unbind('newPost');
             });
           });
         });

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -58,7 +58,7 @@ app.initializers.add('flarum-pusher', () => {
         }
       });
 
-      extend(context, 'onunload', () => channels.main.unbind());
+      extend(context, 'onunload', () => channels.main.unbind('newPost'));
     });
   });
 
@@ -127,7 +127,7 @@ app.initializers.add('flarum-pusher', () => {
         }
       });
 
-      extend(context, 'onunload', () => channels.main.unbind());
+      extend(context, 'onunload', () => channels.main.unbind('newPost'));
     });
   });
 


### PR DESCRIPTION
I was developing a realtime chat based on Pusher and ran into a problem when using the public channel, as this extension would unbind from all events and not `newPost` only.

This PR attemps to fix it by unbinding from `newPost` only.

Disclaimer: It's my first time with Pusher so there might be better ways to do this, I am willing to do any necessary changes.
