### PR TITLE
Fix background size after flarum/core#1496 was merged

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
             "title": "Pusher",
             "icon": {
                 "image": "icon.png",
-                "backgroundSize": "19px 25px",
+                "backgroundSize": "46% 63%",
                 "backgroundPosition": "center",
                 "backgroundRepeat": "no-repeat",
                 "backgroundColor": "#40bad8",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
             "title": "Pusher",
             "icon": {
                 "image": "icon.png",
-                "backgroundSize": "55px 75px",
+                "backgroundSize": "19px 25px",
                 "backgroundPosition": "center",
                 "backgroundRepeat": "no-repeat",
                 "backgroundColor": "#40bad8",


### PR DESCRIPTION
Related to flarum/core#1553

As mentioned in flarum/core#1553, the ratio for the new sizes is 3:1. I tried both `19px` and `18px` for the width, and 19px seemed to fit better and looked more centered.

---

Before:
![image](https://user-images.githubusercontent.com/6401250/44434127-81130a00-a577-11e8-82f6-7cc62b79825f.png)


After:
![image](https://user-images.githubusercontent.com/6401250/44434122-79ebfc00-a577-11e8-8a56-a2ed38116e2a.png)
