### PR TITLE
CDN acceleration

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -10,7 +10,7 @@ import Button from 'flarum/components/Button';
 app.initializers.add('flarum-pusher', () => {
   const loadPusher = m.deferred();
 
-  $.getScript('//js.pusher.com/3.0/pusher.min.js', () => {
+  $.getScript('//cdn.jsdelivr.net/npm/pusher-js@3.0.0/dist/pusher.min.js', () => {
     const socket = new Pusher(app.forum.attribute('pusherKey'), {
       authEndpoint: app.forum.attribute('apiUrl') + '/pusher/auth',
       cluster: app.forum.attribute('pusherCluster'),


### PR DESCRIPTION
Use jsDelivr to increase the loading speed of `pusher.min.js` in China.
The original file from `pusher.com` is slow to load in China.
![image.png](https://i.loli.net/2020/04/15/GYO9iRMj3TNQVHL.png)