### PR TITLE
Reduces friction with flarum/tags

### DIFF
--- a/src/Listener/PushNewPost.php
+++ b/src/Listener/PushNewPost.php
@@ -28,10 +28,12 @@ class PushNewPost
     public function handle(Posted $event)
     {
         if ($event->post->isVisibleTo(new Guest)) {
+            $tags = $event->post->discussion->tags;
+
             $this->pusher->trigger('public', 'newPost', [
                 'postId' => $event->post->id,
                 'discussionId' => $event->post->discussion->id,
-                'tagIds' => $event->post->discussion->tags()->pluck('id')
+                'tagIds' => $tags ? $tags->pluck('id') : null
             ]);
         }
     }


### PR DESCRIPTION
Instead of blatantly triggering a 500 let's try to see whether
the tags relation is even returning anything before we try
to pluck tag ids from it when we publish that data to the pusher
server.

Fixes https://github.com/flarum/core/issues/2282