### PR TITLE
Fix posts not appearing automatically

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -122,7 +122,7 @@ app.initializers.add('flarum-pusher', () => {
           const oldCount = this.discussion.commentCount();
 
           app.store.find('discussions', this.discussion.id()).then(() => {
-            this.stream.update();
+            this.stream.update().then(m.redraw);
 
             if (!document.hasFocus()) {
               app.setTitleCount(Math.max(0, this.discussion.commentCount() - oldCount));


### PR DESCRIPTION
**Fixes flarum/core#3002**

New posts do not appear automatically until I click something (then redraw occurs).
This PR fixes this problem by adding `m.redraw`. Posts appear immediately after being loaded.