### PR TITLE
Fixed broken discussion list pagination when clicking on the update button

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -78,7 +78,7 @@ app.initializers.add('flarum-pusher', () => {
           Button.component({
             className: 'Button Button--block DiscussionList-update',
             onclick: () => {
-              app.discussions.refresh().then(() => {
+              this.attrs.state.refresh().then(() => {
                 this.loadingUpdated = false;
                 app.pushedUpdates = [];
                 app.setTitleCount(0);

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -78,7 +78,7 @@ app.initializers.add('flarum-pusher', () => {
           Button.component({
             className: 'Button Button--block DiscussionList-update',
             onclick: () => {
-              this.attrs.state.refresh(false).then(() => {
+              app.discussions.refresh().then(() => {
                 this.loadingUpdated = false;
                 app.pushedUpdates = [];
                 app.setTitleCount(0);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes [#3111](https://github.com/flarum/core/issues/3111)**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR fixes a bug with broken pagination after clicking on the update button.
More about the issue:  https://github.com/flarum/core/issues/3111

Can this be released as 1.1.1, please?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

https://user-images.githubusercontent.com/25438601/145662457-a240660c-4c94-457d-b223-80f28a74e706.mp4


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
